### PR TITLE
Ephemeral Responses

### DIFF
--- a/config/creepy-dm-subscribers.json
+++ b/config/creepy-dm-subscribers.json
@@ -1,6 +1,4 @@
 {
-  "creepy-dm-subscribers": {
-    "243563136437714944": false
-  },
+  "creepy-dm-subscribers": {},
   "creepy-dm-odds": 0.8
 }

--- a/config/creepy-dm-subscribers.json
+++ b/config/creepy-dm-subscribers.json
@@ -1,4 +1,6 @@
 {
-  "creepy-dm-subscribers": {},
+  "creepy-dm-subscribers": {
+    "243563136437714944": false
+  },
   "creepy-dm-odds": 0.8
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3.9"
 services:
   kardbot:
-    image: tkvarfordt/kardbot:v1.8.4
-    container_name: kardbot-v1.8.4
+    image: tkvarfordt/kardbot:v1.8.5
+    container_name: kardbot-v1.8.5
     volumes:
       - ./config:/app/config
       - ./assets/pasta:/app/assets/pasta

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/deadshot465/owoify-go v1.0.1
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/go-co-op/gocron v1.9.0
+	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
 	github.com/lucasb-eyer/go-colorful v1.2.0
+	github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc
 	github.com/sirupsen/logrus v1.8.1
 	github.com/vartanbeno/go-reddit/v2 v2.0.1
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
@@ -135,6 +137,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc h1:Ak86L+yDSOzKFa7WM5bf5itSOo1e3Xh8bm5YCMUXIjQ=
+github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/kardbot/bot_info.go
+++ b/kardbot/bot_info.go
@@ -22,6 +22,7 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if isSelf, err := authorIsSelf(s, i); err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
 		return
 	} else if isSelf {
 		log.Trace("Ignoring message from self")
@@ -32,17 +33,20 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	fd, err := os.Open(roboCatPng)
 	if err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
 		return
 	}
 	defer fd.Close()
 	mimeType, err := mimetype.DetectReader(fd)
 	if err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
 		return
 	}
 	_, err = fd.Seek(0, 0)
 	if err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
 		return
 	}
 

--- a/kardbot/bot_info.go
+++ b/kardbot/bot_info.go
@@ -22,7 +22,7 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if isSelf, err := authorIsSelf(s, i); err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	} else if isSelf {
 		log.Trace("Ignoring message from self")
@@ -33,20 +33,20 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	fd, err := os.Open(roboCatPng)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	}
 	defer fd.Close()
 	mimeType, err := mimetype.DetectReader(fd)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	}
 	_, err = fd.Seek(0, 0)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	}
 
@@ -78,6 +78,6 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 	}
 }

--- a/kardbot/bot_info.go
+++ b/kardbot/bot_info.go
@@ -65,6 +65,7 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
+			Flags:  InteractionResponseFlagEphemeral,
 			Embeds: []*discordgo.MessageEmbed{embed.Truncate().MessageEmbed},
 			Files: []*discordgo.File{
 				{
@@ -77,5 +78,6 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, err)
 	}
 }

--- a/kardbot/bot_info.go
+++ b/kardbot/bot_info.go
@@ -22,7 +22,7 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if isSelf, err := authorIsSelf(s, i); err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	} else if isSelf {
 		log.Trace("Ignoring message from self")
@@ -33,20 +33,20 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	fd, err := os.Open(roboCatPng)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 	defer fd.Close()
 	mimeType, err := mimetype.DetectReader(fd)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 	_, err = fd.Seek(0, 0)
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -78,6 +78,6 @@ func botInfo(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }

--- a/kardbot/commands.go
+++ b/kardbot/commands.go
@@ -381,3 +381,9 @@ func validateCmdRegex() bool {
 
 	return conforms
 }
+
+func getComponentImpls() map[string]onInteractionHandler {
+	return map[string]onInteractionHandler{
+		selectMenuErrorReport: handleErrorReportSelection,
+	}
+}

--- a/kardbot/compliments.go
+++ b/kardbot/compliments.go
@@ -137,6 +137,7 @@ func morningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -151,10 +152,12 @@ func morningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: fmt.Sprintf("%s, you are subscribed to receive morning compliments as long as the bot is up, but there was an error persisting your subscription. Please try to opt-in again.", metadata.AuthorUsername),
+				Flags:   InteractionResponseFlagEphemeral,
 			},
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 		}
 		return
 	}
@@ -168,6 +171,7 @@ func morningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }
 
@@ -175,6 +179,7 @@ func morningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -189,10 +194,12 @@ func morningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: fmt.Sprintf("%s, you are unsubscribed from morning compliments as long as the bot is up, but there was an error persisting your opt-out. Please try to opt-out again.", metadata.AuthorUsername),
+				Flags:   InteractionResponseFlagEphemeral,
 			},
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 		}
 		return
 	}
@@ -207,6 +214,7 @@ func morningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }
 
@@ -214,6 +222,7 @@ func eveningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -228,10 +237,12 @@ func eveningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: fmt.Sprintf("%s, you are subscribed to receive evening compliments as long as the bot is up, but there was an error persisting your subscription. Please try to opt-in again.", metadata.AuthorUsername),
+				Flags:   InteractionResponseFlagEphemeral,
 			},
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 		}
 		return
 	}
@@ -245,6 +256,7 @@ func eveningComplimentOptIn(s *discordgo.Session, i *discordgo.InteractionCreate
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }
 
@@ -252,6 +264,7 @@ func eveningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -266,10 +279,12 @@ func eveningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: fmt.Sprintf("%s, you are unsubscribed from evening compliments as long as the bot is up, but there was an error persisting your opt-out. Please try to opt-out again.", metadata.AuthorUsername),
+				Flags:   InteractionResponseFlagEphemeral,
 			},
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 		}
 		return
 	}
@@ -283,6 +298,7 @@ func eveningComplimentOptOut(s *discordgo.Session, i *discordgo.InteractionCreat
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }
 
@@ -290,6 +306,7 @@ func getCompliment(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -303,9 +320,13 @@ func getCompliment(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if sendAsDM {
 		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Flags: InteractionResponseFlagEphemeral,
+			},
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 			return
 		}
 
@@ -320,9 +341,12 @@ func getCompliment(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		log.Infof("Told %s that '%s'", metadata.AuthorUsername, compliment)
 
 		time.Sleep(time.Millisecond * 250) // give a bit for the initial response to be received
-		err = s.InteractionResponseDelete(s.State.User.ID, i.Interaction)
+		_, err = s.InteractionResponseEdit(s.State.User.ID, i.Interaction, &discordgo.WebhookEdit{
+			Content: "Sent you a compliment! 💛",
+		})
 		if err != nil {
 			log.Error(err)
+			interactionFollowUpEphemeralError(s, i, true, err)
 		}
 		return
 	}
@@ -335,8 +359,8 @@ func getCompliment(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 	}
-	log.Infof("To %s: \"%s\"", metadata.AuthorUsername, compliment)
 }
 
 func sendMorningCompliments() {

--- a/kardbot/debug.go
+++ b/kardbot/debug.go
@@ -1,6 +1,7 @@
 package kardbot
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -44,9 +45,8 @@ func updateLogLevel(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		interactionRespondEphemeralError(s, i, true, err)
 		return
 	} else if !isOwner {
-		err = fmt.Errorf("user %s (%s) does not have privilege to update log level", metadata.AuthorUsername, metadata.AuthorID)
-		log.Warn(err)
-		interactionRespondEphemeralError(s, i, false, err)
+		log.Warnf("user %s (%s) does not have privilege to update log level", metadata.AuthorUsername, metadata.AuthorID)
+		interactionRespondEphemeralError(s, i, false, errors.New("you do not have permissions to update the log level. :("))
 		return
 	}
 

--- a/kardbot/debug.go
+++ b/kardbot/debug.go
@@ -41,9 +41,12 @@ func updateLogLevel(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if isOwner, err := authorIsOwner(i); err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	} else if !isOwner {
-		log.Warnf("User %s (%s) does not have privilege to update log level", metadata.AuthorUsername, metadata.AuthorID)
+		err = fmt.Errorf("user %s (%s) does not have privilege to update log level", metadata.AuthorUsername, metadata.AuthorID)
+		log.Warn(err)
+		interactionRespondEphemeralError(s, i, false, err)
 		return
 	}
 
@@ -58,7 +61,7 @@ func updateLogLevel(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			s.LogLevel = logrusToDiscordGo()[lvl]
 			bot().dgLoggingMutex.Unlock()
 		}
-		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: info,
@@ -66,9 +69,11 @@ func updateLogLevel(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		})
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 		}
 	} else {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }
 

--- a/kardbot/interactionErrHandling.go
+++ b/kardbot/interactionErrHandling.go
@@ -1,0 +1,301 @@
+package kardbot
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/TannerKvarfordt/Kard-bot/kardbot/dg_helpers"
+	"github.com/bwmarrin/discordgo"
+	"github.com/google/uuid"
+	cmap "github.com/orcaman/concurrent-map"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	genericErrorString    = "an error occurred. :'("
+	selectMenuErrorReport = "select_error_report"
+)
+
+type errReportSelectionValue struct {
+	// UUID of the associated errorReport
+	ErrUUID uuid.UUID `json:"error-uuid,omitempty"`
+	// Should the errorReport be made anonymously?
+	Anonymous bool `json:"anonymous,omitempty"`
+}
+
+func (ers errReportSelectionValue) MarshalToString() string {
+	buf, err := json.Marshal(ers)
+	if err != nil {
+		log.Error(err)
+	}
+	return string(buf)
+}
+
+func (ers *errReportSelectionValue) UnmarshalFromString(ersStr string) error {
+	return json.Unmarshal([]byte(ersStr), &ers)
+}
+
+type errorReport struct {
+	// UUID of this error report
+	UUID uuid.UUID
+	// The InteractionCreate event that caused the error
+	InteractionCreate discordgo.InteractionCreate
+	// The error that arose during the InteractionCreate event
+	Err error
+}
+
+var (
+	// Maps UUIDs to errorReports
+	errsToReport = cmap.New()
+
+	errReportMsgComponents = func(errUUID uuid.UUID) []discordgo.MessageComponent {
+		ownerMention := ""
+		if getOwnerID() == "" {
+			ownerMention = "the bot owner"
+		} else {
+			owner, err := bot().Session.User(getOwnerID())
+			if err != nil {
+				log.Error(err)
+				ownerMention = "the bot owner"
+			} else {
+				ownerMention = owner.Username
+			}
+		}
+		return []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.SelectMenu{
+						CustomID:    selectMenuErrorReport,
+						Placeholder: "Would you like to send an error report?",
+						Options: []discordgo.SelectMenuOption{
+							{
+								Label:       "Send Anonymous Error Report",
+								Description: fmt.Sprintf("Send an anonymous error report to %s.", ownerMention),
+								Value:       errReportSelectionValue{errUUID, true}.MarshalToString(),
+								Default:     false,
+								Emoji: discordgo.ComponentEmoji{
+									Name: "📮",
+								},
+							},
+							{
+								Label:       "Send Error Report",
+								Description: fmt.Sprintf("Send an error report to %s.", ownerMention),
+								Default:     false,
+								Value:       errReportSelectionValue{errUUID, false}.MarshalToString(),
+								Emoji: discordgo.ComponentEmoji{
+									Name: "🗳️",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+)
+
+func interactionRespondEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, notifyOwner bool, errResp error) {
+	if s == nil {
+		log.Error("nil session")
+		return
+	}
+	if i == nil {
+		log.Error("nil interaction")
+		return
+	}
+	if errResp == nil {
+		log.Warn("empty errStr, using generic error: ", genericErrorString)
+		errResp = errors.New(genericErrorString)
+	}
+
+	if !notifyOwner {
+		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprint(errResp),
+				Flags:   InteractionResponseFlagEphemeral,
+			},
+		})
+		if err != nil {
+			log.Error(err)
+		}
+		return
+	}
+
+	if getOwnerID() == "" {
+		log.Error("No ownerID provided, cannot send error report")
+		return
+	}
+
+	errUUID := uuid.New()
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content:    "Something went wrong while processing your command. 😔",
+			Flags:      InteractionResponseFlagEphemeral,
+			Components: errReportMsgComponents(errUUID),
+		},
+	})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	errsToReport.Set(fmt.Sprint(errUUID), errorReport{
+		UUID:              errUUID,
+		Err:               errResp,
+		InteractionCreate: *i,
+	})
+}
+
+// Assumes that a deferred response has already been sent.
+// Will delete the deferred response and send an ephemeral follow up response.
+func interactionFollowUpEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, notifyOwner bool, errResp error) {
+	if s == nil {
+		log.Error("nil session")
+		return
+	}
+	if i == nil {
+		log.Error("nil interaction")
+		return
+	}
+	if errResp == nil {
+		log.Warn("empty errStr, using generic error: ", genericErrorString)
+		errResp = errors.New(genericErrorString)
+	}
+
+	err := s.InteractionResponseDelete(s.State.User.ID, i.Interaction)
+	if err != nil {
+		log.Error(err)
+	}
+
+	if !notifyOwner {
+		_, err = s.FollowupMessageCreate(s.State.User.ID, i.Interaction, false, &discordgo.WebhookParams{
+			Content: fmt.Sprint(errResp),
+			Flags:   InteractionResponseFlagEphemeral,
+		})
+		if err != nil {
+			log.Error(err)
+		}
+		return
+	}
+
+	errUUID := uuid.New()
+	_, err = s.FollowupMessageCreate(s.State.User.ID, i.Interaction, false, &discordgo.WebhookParams{
+		Content:    "Something went wrong while processing your command. 😔",
+		Flags:      InteractionResponseFlagEphemeral,
+		Components: errReportMsgComponents(errUUID),
+	})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	errsToReport.Set(fmt.Sprint(errUUID), errorReport{
+		UUID:              errUUID,
+		Err:               errResp,
+		InteractionCreate: *i,
+	})
+}
+
+func handleErrorReportSelection(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	wg := bot().updateLastActive()
+	defer wg.Wait()
+
+	data := i.MessageComponentData()
+	if len(data.Values) == 0 {
+		log.Error("No values returned with component interaction data")
+		return
+	}
+
+	selection := errReportSelectionValue{}
+	err := selection.UnmarshalFromString(data.Values[0])
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	iErrReport, ok := errsToReport.Get(selection.ErrUUID.String())
+	if !ok {
+		log.Errorf("No error report found with UUID=%s", selection.ErrUUID)
+		return
+	}
+
+	errReport, ok := iErrReport.(errorReport)
+	if !ok {
+		log.Error("Could not convert interface to errorReport")
+		return
+	}
+
+	err = dmOwnerErrorReport(s, errReport, selection.Anonymous)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	ownerMention := ""
+	if getOwnerID() == "" {
+		ownerMention = "The bot owner"
+	} else {
+		ownerMention = fmt.Sprintf("<@%s>", getOwnerID())
+	}
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("%s\nThanks for submitting an error report! %s has been notified of the problem.", i.Message.Content, ownerMention),
+			Flags:   InteractionResponseFlagEphemeral,
+			AllowedMentions: &discordgo.MessageAllowedMentions{
+				Users: []string{getOwnerID()},
+			},
+			// No good way to delete components from a message, so this will have to do for now.
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.Button{
+							CustomID: "no_handler",
+							Label:    "Error Report Submitted",
+							Style:    discordgo.SecondaryButton,
+							Disabled: true,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	errsToReport.Remove(selection.ErrUUID.String())
+}
+
+func dmOwnerErrorReport(s *discordgo.Session, errReport errorReport, anonymous bool) error {
+	if s == nil {
+		return errors.New("nil session provided")
+	}
+	metadata, err := getInteractionMetaData(&errReport.InteractionCreate)
+	if err != nil {
+		return err
+	}
+	uc, err := bot().Session.UserChannelCreate(metadata.AuthorID)
+	if err != nil {
+		return err
+	}
+	cmdJson, err := json.MarshalIndent(errReport.InteractionCreate.ApplicationCommandData(), "", "  ")
+	if err != nil {
+		return err
+	}
+	embed := dg_helpers.NewEmbed()
+	if anonymous {
+		embed.AddField("Afflicted User", "anonymous")
+	} else {
+		embed.AddField("Afflicted User", metadata.AuthorMention)
+	}
+	_, err = s.ChannelMessageSendComplex(uc.ID, &discordgo.MessageSend{
+		Embed: embed.SetTitle("Error Report").
+			AddField("Issued Command", fmt.Sprintf("```json\n%s\n```", cmdJson)).
+			AddField("Error", fmt.Sprintf("```\n%s\n```", errReport.Err)).
+			Truncate().
+			MessageEmbed,
+	})
+	return err
+}

--- a/kardbot/interactionErrHandling.go
+++ b/kardbot/interactionErrHandling.go
@@ -238,6 +238,11 @@ func handleErrorReportSelection(s *discordgo.Session, i *discordgo.InteractionCr
 	} else {
 		ownerMention = fmt.Sprintf("<@%s>", getOwnerID())
 	}
+
+	buttonPrefix := ""
+	if selection.Anonymous {
+		buttonPrefix = "Anonymous "
+	}
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
@@ -252,7 +257,7 @@ func handleErrorReportSelection(s *discordgo.Session, i *discordgo.InteractionCr
 					Components: []discordgo.MessageComponent{
 						discordgo.Button{
 							CustomID: "no_handler",
-							Label:    "Error Report Submitted",
+							Label:    fmt.Sprintf("%sError Report Submitted", buttonPrefix),
 							Style:    discordgo.SecondaryButton,
 							Disabled: true,
 						},

--- a/kardbot/interactionErrHandling.go
+++ b/kardbot/interactionErrHandling.go
@@ -166,7 +166,7 @@ func interactionFollowUpEphemeralError(s *discordgo.Session, i *discordgo.Intera
 
 	err := s.InteractionResponseDelete(s.State.User.ID, i.Interaction)
 	if err != nil {
-		log.Error(err)
+		log.Warn(err)
 	}
 
 	if !notifyOwner {

--- a/kardbot/interactionUtils.go
+++ b/kardbot/interactionUtils.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const InteractionResponseFlagEphemeral = 1 << 6
+const InteractionResponseFlagEphemeral = uint64(1 << 6)
 
 const genericErrorString = "an error occurred. :'("
 

--- a/kardbot/interactionUtils.go
+++ b/kardbot/interactionUtils.go
@@ -1,129 +1,13 @@
 package kardbot
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/TannerKvarfordt/Kard-bot/kardbot/dg_helpers"
 	"github.com/bwmarrin/discordgo"
-	log "github.com/sirupsen/logrus"
 )
 
 const InteractionResponseFlagEphemeral = uint64(1 << 6)
-
-const genericErrorString = "an error occurred. :'("
-
-func interactionRespondWithEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, errStr string) {
-	if s == nil {
-		log.Error("nil session")
-		return
-	}
-	if i == nil {
-		log.Error("nil interaction")
-		return
-	}
-	if errStr == "" {
-		log.Warn("empty errStr, using generic error: ", genericErrorString)
-		errStr = genericErrorString
-	}
-
-	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: errStr,
-			Flags:   InteractionResponseFlagEphemeral,
-		},
-	})
-	if err != nil {
-		log.Error(err)
-	}
-}
-
-func interactionRespondWithEphemeralErrorAndNotifyOwner(s *discordgo.Session, i *discordgo.InteractionCreate, errResp error) {
-	ownerID := getOwnerID()
-	if ownerID == "" {
-		ownerID = "The bot owner"
-	} else {
-		ownerID = fmt.Sprintf("<@%s>", ownerID)
-	}
-	interactionRespondWithEphemeralError(s, i, fmt.Sprintf("Something went wrong while processing your command. 😔 %s has been notified.", ownerID))
-	dmOwnerErrorReport(s, i, errResp)
-}
-
-// Assumes that a deferred response has already been sent.
-// Will delete the deferred response and send an ephemeral follow up response.
-func interactionFollowUpWithEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, errStr string) {
-	if s == nil {
-		log.Error("nil session")
-		return
-	}
-	if i == nil {
-		log.Error("nil interaction")
-		return
-	}
-	if errStr == "" {
-		log.Warn("empty errStr, using generic error: ", genericErrorString)
-		errStr = genericErrorString
-	}
-
-	err := s.InteractionResponseDelete(s.State.User.ID, i.Interaction)
-	if err != nil {
-		log.Error(err)
-	}
-	_, err = s.FollowupMessageCreate(s.State.User.ID, i.Interaction, false, &discordgo.WebhookParams{
-		Content: errStr,
-		Flags:   InteractionResponseFlagEphemeral,
-	})
-	if err != nil {
-		log.Error(err)
-	}
-}
-
-// Assumes that a deferred response has already been sent.
-// Will delete the deferred response and send an ephemeral follow up response.
-func interactionFollowUpWithEphemeralErrorAndNotifyOwner(s *discordgo.Session, i *discordgo.InteractionCreate, errResp error) {
-	ownerID := getOwnerID()
-	if ownerID == "" {
-		ownerID = "The bot owner"
-	} else {
-		ownerID = fmt.Sprintf("<@%s>", ownerID)
-	}
-	interactionFollowUpWithEphemeralError(s, i, fmt.Sprintf("Something went wrong while processing your command. 😔 %s has been notified.", ownerID))
-	dmOwnerErrorReport(s, i, errResp)
-}
-
-func dmOwnerErrorReport(s *discordgo.Session, i *discordgo.InteractionCreate, errResp error) {
-	metadata, err := getInteractionMetaData(i)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	uc, err := bot().Session.UserChannelCreate(metadata.AuthorID)
-	if err != nil {
-		log.Error(err)
-	}
-
-	cmdJson, err := json.MarshalIndent(i.ApplicationCommandData(), "", "  ")
-	if err != nil {
-		log.Error(err)
-		cmdJson = []byte(`"error": "Error marshalling application command"`)
-	}
-
-	_, err = bot().Session.ChannelMessageSendComplex(uc.ID, &discordgo.MessageSend{
-		Embed: dg_helpers.NewEmbed().
-			SetTitle("Error Report").
-			AddField("Afflicted User", metadata.AuthorMention).
-			AddField("Issued Command", fmt.Sprintf("```json\n%s\n```", cmdJson)).
-			AddField("Error", fmt.Sprintf("```\n%s\n```", errResp)).
-			Truncate().
-			MessageEmbed,
-	})
-	if err != nil {
-		log.Error(err)
-	}
-}
 
 func authorIsSelf(s *discordgo.Session, i *discordgo.InteractionCreate) (bool, error) {
 	if s == nil || i == nil {

--- a/kardbot/interactionUtils.go
+++ b/kardbot/interactionUtils.go
@@ -14,7 +14,7 @@ const InteractionResponseFlagEphemeral = uint64(1 << 6)
 
 const genericErrorString = "an error occurred. :'("
 
-func interactionRespondWithEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, respType discordgo.InteractionResponseType, errStr string) {
+func interactionRespondWithEphemeralError(s *discordgo.Session, i *discordgo.InteractionCreate, errStr string) {
 	if s == nil {
 		log.Error("nil session")
 		return
@@ -29,7 +29,7 @@ func interactionRespondWithEphemeralError(s *discordgo.Session, i *discordgo.Int
 	}
 
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: respType,
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: errStr,
 			Flags:   InteractionResponseFlagEphemeral,
@@ -40,14 +40,14 @@ func interactionRespondWithEphemeralError(s *discordgo.Session, i *discordgo.Int
 	}
 }
 
-func interactionRespondWithEphemeralErrorAndNotifyOwner(s *discordgo.Session, i *discordgo.InteractionCreate, respType discordgo.InteractionResponseType, errResp error) {
+func interactionRespondWithEphemeralErrorAndNotifyOwner(s *discordgo.Session, i *discordgo.InteractionCreate, errResp error) {
 	ownerID := getOwnerID()
 	if ownerID == "" {
 		ownerID = "The bot owner"
 	} else {
 		ownerID = fmt.Sprintf("<@%s>", ownerID)
 	}
-	interactionRespondWithEphemeralError(s, i, respType, fmt.Sprintf("Something went wrong while processing your command. 😔 %s has been notified.", ownerID))
+	interactionRespondWithEphemeralError(s, i, fmt.Sprintf("Something went wrong while processing your command. 😔 %s has been notified.", ownerID))
 
 	metadata, err := getInteractionMetaData(i)
 	if err != nil {

--- a/kardbot/kardbot.go
+++ b/kardbot/kardbot.go
@@ -233,7 +233,7 @@ func (kbot *kardbot) prepInteractionHandlers() {
 			// Won't do any good if the panic came from another goroutine.
 			if r := recover(); r != nil {
 				if panicErr, ok := r.(error); ok {
-					interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, discordgo.InteractionResponseChannelMessageWithSource, panicErr)
+					interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, panicErr)
 				}
 				log.Fatalf("Panicked!\n%v", r)
 			}

--- a/kardbot/memetools.go
+++ b/kardbot/memetools.go
@@ -1,6 +1,7 @@
 package kardbot
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -219,7 +220,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
-		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -227,7 +228,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if !ok {
 		errmsg := fmt.Sprintf("Error! No template found with name %s", i.ApplicationCommandData().Options[0].Name)
 		log.Error(errmsg)
-		interactionFollowUpWithEphemeralError(s, i, errmsg)
+		interactionFollowUpEphemeralError(s, i, true, errors.New(errmsg))
 		return
 	}
 
@@ -259,7 +260,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boxIdx, err := strconv.Atoi(arg.Name)
 			if err != nil {
 				log.Error(err)
-				interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
+				interactionFollowUpEphemeralError(s, i, true, err)
 				return
 			}
 			if boxIdx >= len(boxes) {
@@ -293,7 +294,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
-		interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -307,6 +308,6 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
-		interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 	}
 }

--- a/kardbot/memetools.go
+++ b/kardbot/memetools.go
@@ -219,12 +219,15 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	}
 
 	template, ok := memeTemplates()[i.ApplicationCommandData().Options[templateOptIdx].StringValue()]
 	if !ok {
-		log.Errorf("No template found with name %s", i.ApplicationCommandData().Options[0].Name)
+		errmsg := fmt.Sprintf("Error! No template found with name %s", i.ApplicationCommandData().Options[0].Name)
+		log.Error(errmsg)
+		interactionFollowUpWithEphemeralError(s, i, errmsg)
 		return
 	}
 
@@ -256,6 +259,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			boxIdx, err := strconv.Atoi(arg.Name)
 			if err != nil {
 				log.Error(err)
+				interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
 				return
 			}
 			if boxIdx >= len(boxes) {
@@ -289,6 +293,7 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
 		return
 	}
 
@@ -302,5 +307,6 @@ func buildAMeme(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionFollowUpWithEphemeralErrorAndNotifyOwner(s, i, err)
 	}
 }

--- a/kardbot/pasta.go
+++ b/kardbot/pasta.go
@@ -3,6 +3,7 @@ package kardbot
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -126,10 +127,14 @@ func servePasta(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		content, err = p.makePasta()
 		if err != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err)
 			return
 		}
 	} else {
-		log.Error("invalid selection: ", selection)
+		err := fmt.Errorf("invalid selection: %s", selection)
+		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
+		return
 	}
 
 	tts := false
@@ -164,5 +169,6 @@ func servePasta(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }

--- a/kardbot/storytime.go
+++ b/kardbot/storytime.go
@@ -112,6 +112,7 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	defer wg.Wait()
 	if isSelf, err := authorIsSelf(s, i); err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	} else if isSelf {
 		log.Trace("Ignoring message from self")
@@ -135,10 +136,12 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Embeds: []*discordgo.MessageEmbed{buildStoryTimeHelpEmbed()},
+					Flags:  InteractionResponseFlagEphemeral,
 				},
 			})
 			if err != nil {
 				log.Error(err)
+				interactionRespondEphemeralError(s, i, true, err)
 			}
 			return
 		default:
@@ -152,10 +155,12 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: fmt.Sprintf("%s is not a valid model", model),
+				Flags:   InteractionResponseFlagEphemeral,
 			},
 		})
 		if err2 != nil {
 			log.Error(err)
+			interactionRespondEphemeralError(s, i, true, err2)
 		}
 		return
 	}
@@ -165,6 +170,7 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -182,10 +188,13 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 		return
 	}
 	if len(textResps) == 0 || len(textResps[0].GeneratedTexts) == 0 || textResps[0].GeneratedTexts[0] == "" {
-		log.Error("Received no text generation responses")
+		err = fmt.Errorf("received no text generation responses")
+		log.Error(err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 		return
 	}
 
@@ -201,6 +210,7 @@ func storyTime(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionFollowUpEphemeralError(s, i, true, err)
 	}
 }
 

--- a/kardbot/uwu.go
+++ b/kardbot/uwu.go
@@ -50,6 +50,7 @@ func uwuify(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if isSelf, err := authorIsSelf(s, i); err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 		return
 	} else if isSelf {
 		log.Trace("Ignoring message from self")
@@ -63,6 +64,7 @@ func uwuify(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			content, err = p.makePasta()
 			if err != nil {
 				log.Error(err)
+				interactionRespondEphemeralError(s, i, true, err)
 				return
 			}
 		}
@@ -91,5 +93,6 @@ func uwuify(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	})
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }

--- a/kardbot/whataretheodds.go
+++ b/kardbot/whataretheodds.go
@@ -28,5 +28,6 @@ func whatAreTheOdds(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	if err != nil {
 		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
 	}
 }


### PR DESCRIPTION
This PR adds ephemeral responses per #35. Prior to this PR, if a command failed it would do so silently with no feedback to the user. The goal of these changes is to provide useful feedback that only the issuing user can see when a command fails, as well as give the user the option to submit an error report to the bot owner.

Closes #35.