### PR TITLE
Role menu subcommands

### DIFF
--- a/config/setup.json
+++ b/config/setup.json
@@ -1,5 +1,11 @@
 {
   "enable-dg-logging": false,
   "default-log-level": "info",
-  "unregister-all-cmds-on-startup": false
+  "unregister-all-cmds-on-startup": false,
+  "pprof": {
+    "enabled": false,
+    "address": "localhost:6060",
+    "block-profile-rate": 0,
+    "mutex-profile-fraction": 0
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3.9"
 services:
   kardbot:
-    image: tkvarfordt/kardbot:v1.9.0
-    container_name: kardbot-v1.9.0
+    image: tkvarfordt/kardbot:v1.9.1
+    container_name: kardbot-v1.9.1
     volumes:
       - ./config:/app/config
       - ./assets/pasta:/app/assets/pasta

--- a/kardbot/commands.go
+++ b/kardbot/commands.go
@@ -15,6 +15,7 @@ const (
 	maxDiscordOptionChoices  = 25
 	maxDiscordSelectMenuOpts = 25
 	maxDiscordActionRows     = 5
+	minDiscordSelectMenuOpts = 2 // discord requires at least this many options per SelectMenu
 )
 
 func getCommands() []*discordgo.ApplicationCommand {

--- a/kardbot/commands.go
+++ b/kardbot/commands.go
@@ -323,7 +323,7 @@ func getCommands() []*discordgo.ApplicationCommand {
 			},
 		},
 		{
-			Name:        createRoleSelectCommand,
+			Name:        roleSelectMenuCommand,
 			Description: "Allow users to select roles for themselves",
 			Options:     roleSelectCmdOpts(),
 		},
@@ -342,19 +342,19 @@ func getCommands() []*discordgo.ApplicationCommand {
 
 func getCommandImpls() map[string]onInteractionHandler {
 	return map[string]onInteractionHandler{
-		RollCmd:                 roll,
-		"loglevel":              updateLogLevel,
-		"pasta":                 servePasta,
-		"reddit-roulette":       redditRoulette,
-		"uwu":                   uwuify,
-		"compliments":           complimentHandler,
-		"creepy-dms":            creepyDMHandler,
-		"help":                  botInfo,
-		"what-are-the-odds":     whatAreTheOdds,
-		memeCommand:             buildAMeme,
-		delBotDMCmd:             deleteBotDMs,
-		storyTimeCmd:            storyTime,
-		createRoleSelectCommand: createRoleSelect,
+		RollCmd:               roll,
+		"loglevel":            updateLogLevel,
+		"pasta":               servePasta,
+		"reddit-roulette":     redditRoulette,
+		"uwu":                 uwuify,
+		"compliments":         complimentHandler,
+		"creepy-dms":          creepyDMHandler,
+		"help":                botInfo,
+		"what-are-the-odds":   whatAreTheOdds,
+		memeCommand:           buildAMeme,
+		delBotDMCmd:           deleteBotDMs,
+		storyTimeCmd:          storyTime,
+		roleSelectMenuCommand: handleRoleSelectMenuCommand,
 	}
 }
 

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -258,6 +258,18 @@ func strMatchesRoleSelectMenuID(str string) bool {
 }
 
 func handleRoleSelectMenuCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	wg := bot().updateLastActive()
+	defer wg.Wait()
+
+	if isAdmin, err := isInteractionIssuerAdmin(i); err != nil {
+		interactionRespondEphemeralError(s, i, true, err)
+		log.Error(err)
+		return
+	} else if !isAdmin {
+		interactionRespondEphemeralError(s, i, false, fmt.Errorf("you must run this command from a server you administer"))
+		return
+	}
+
 	switch i.ApplicationCommandData().Options[0].Name {
 	case roleSelectMenuSubCmdCreate:
 		handleRoleSelectMenuCreate(s, i)
@@ -452,17 +464,6 @@ func validateRoleSelectEmbedURLs(e *dg_helpers.Embed) error {
 func handleRoleSelectMenuUpdate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if s == nil || i == nil {
 		log.Errorf("nil Session pointer (%v) and/or InteractionCreate pointer (%v)", s, i)
-		return
-	}
-	wg := bot().updateLastActive()
-	defer wg.Wait()
-
-	if isAdmin, err := isInteractionIssuerAdmin(i); err != nil {
-		interactionRespondEphemeralError(s, i, true, err)
-		log.Error(err)
-		return
-	} else if !isAdmin {
-		interactionRespondEphemeralError(s, i, false, fmt.Errorf("you must run this command from a server you administer"))
 		return
 	}
 
@@ -906,17 +907,6 @@ func isMessageARoleSelectMenu(s *discordgo.Session, m *discordgo.Message) error 
 func handleRoleSelectMenuCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if s == nil || i == nil {
 		log.Errorf("nil Session pointer (%v) and/or InteractionCreate pointer (%v)", s, i)
-		return
-	}
-	wg := bot().updateLastActive()
-	defer wg.Wait()
-
-	if isAdmin, err := isInteractionIssuerAdmin(i); err != nil {
-		interactionRespondEphemeralError(s, i, true, err)
-		log.Error(err)
-		return
-	} else if !isAdmin {
-		interactionRespondEphemeralError(s, i, false, fmt.Errorf("you must be a server administrator to run this command"))
 		return
 	}
 

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -1007,9 +1007,9 @@ func getPossibleRoleIDs(i *discordgo.InteractionCreate, buttonID string) (map[st
 		return nil, fmt.Errorf("nil interaction")
 	}
 
-	var possibleRoleIDs map[string]bool
+	var possibleRoleIDs map[string]bool = nil
 	for _, ar := range i.Message.Components {
-		if ar == nil {
+		if ar == nil || ar.Type() != discordgo.ActionsRowComponent {
 			continue
 		}
 		actionRow, ok := ar.(*discordgo.ActionsRow)
@@ -1017,10 +1017,7 @@ func getPossibleRoleIDs(i *discordgo.InteractionCreate, buttonID string) (map[st
 			return nil, fmt.Errorf("bad cast to *discordgo.ActionsRow, type is %T", ar)
 		}
 		for _, sm := range actionRow.Components {
-			if sm == nil {
-				continue
-			}
-			if sm.Type() != discordgo.SelectMenuComponent {
+			if sm == nil || sm.Type() != discordgo.SelectMenuComponent {
 				continue
 			}
 
@@ -1030,14 +1027,16 @@ func getPossibleRoleIDs(i *discordgo.InteractionCreate, buttonID string) (map[st
 			}
 
 			if selectMenu.CustomID == buttonID || buttonID == "" {
-				possibleRoleIDs = make(map[string]bool, len(selectMenu.Options))
+				if possibleRoleIDs == nil {
+					possibleRoleIDs = make(map[string]bool, len(selectMenu.Options))
+				}
 				for _, opt := range selectMenu.Options {
 					possibleRoleIDs[opt.Value] = false
 				}
 				break
 			}
 		}
-		if len(possibleRoleIDs) > 0 {
+		if len(possibleRoleIDs) > 0 && buttonID != "" {
 			break
 		}
 	}

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -1096,6 +1096,7 @@ func handleRoleSelection(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	var (
 		rolesToAddOrKeep = make([]string, 0, len(selectMenuRoleIDs)+len(i.MessageComponentData().Values))
 		rolesToRemove    = make([]string, 0, len(selectMenuRoleIDs))
+		addedRoles       = make([]string, 0, len(i.MessageComponentData().Values))
 	)
 
 	for _, roleID := range metadata.AuthorGuildRoles {
@@ -1116,6 +1117,7 @@ func handleRoleSelection(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		}
 		if !alreadyPresent {
 			rolesToAddOrKeep = append(rolesToAddOrKeep, roleID)
+			addedRoles = append(addedRoles, roleID)
 		}
 	}
 
@@ -1133,8 +1135,8 @@ func handleRoleSelection(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 
 	embed := dg_helpers.NewEmbed().SetTitle("Your Roles Have Been Updated 🎭").SetColor(int(embedColor))
-	if len(i.MessageComponentData().Values) != 0 {
-		embed.AddField("Current Roles ✅", "<@&"+strings.Join(i.MessageComponentData().Values, ">\n<@&")+">")
+	if len(addedRoles) != 0 {
+		embed.AddField("Added Roles ✅", "<@&"+strings.Join(addedRoles, ">\n<@&")+">")
 	}
 	if len(rolesToRemove) != 0 {
 		embed.AddField("Removed Roles ❌", "<@&"+strings.Join(rolesToRemove, ">\n<@&")+">")

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -53,8 +53,8 @@ const (
 
 	roleSelectMenuUpdateOptAction          = "action"
 	roleSelectMenuUpdateOptReqAction       = true
-	roleSelectMenuUpdateOptActionChoiceAdd = "add"
-	roleSelectMenuUpdateOptActionChoiceDel = "delete"
+	roleSelectMenuUpdateOptActionChoiceAdd = "add-role"
+	roleSelectMenuUpdateOptActionChoiceDel = "delete-role"
 	roleSelectMenuUpdateOptMsgID           = "message-id"
 	roleSelectMenuUpdateOptReqMsgID        = true
 	roleSelectMenuUpdateOptRole            = "role"

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -14,115 +14,120 @@ import (
 )
 
 const (
-	createRoleSelectCommand = "create-role-menu"
-
-	roleSelectMenuTitleOpt    = "title"
-	roleSelectMenuTitleOptReq = true
-
-	roleSelectRolesOpt    = "roles"
-	roleSelectRolesOptReq = true
 	maxRoleSelectMenus    = 4
+	roleSelectMenuCommand = "role-select-menu"
+	// TODO: Add a help subcommand
+)
 
-	roleSelectMenuDescOpt    = "description"
-	roleSelectMenuDescOptReq = false
+const (
+	roleSelectMenuSubCmdCreate = "create"
 
-	roleSelectMenuURLOpt    = "url"
-	roleSelectMenuURLOptReq = false
+	roleSelectMenuCreateOptTitle        = "title"
+	roleSelectMenuCreateOptReqTitle     = true
+	roleSelectMenuCreateOptRoles        = "roles"
+	roleSelectMenuCreateOptReqRoles     = true
+	roleSelectMenuCreateOptDesc         = "description"
+	roleSelectMenuCreateOptReqDesc      = false
+	roleSelectMenuCreateOptURL          = "url"
+	roleSelectMenuCreateOptReqURL       = false
+	roleSelectMenuCreateOptImage        = "image-url"
+	roleSelectMenuCreateOptReqImage     = false
+	roleSelectMenuCreateOptThumbnail    = "thumbnail-url"
+	roleSelectMenuCreateOptReqThumbnail = false
+	roleSelectMenuCreateOptColor        = "embed-color"
+	roleSelectMenuCreateOptReqColor     = false
+)
+const (
+	roleSelectMenuCreateOptIdxTitle = iota
+	roleSelectMenuCreateOptIdxRoles
+	roleSelectMenuCreateOptIdxDesc      // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuCreateOptIdxURL       // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuCreateOptIdxImage     // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuCreateOptIdxThumbnail // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuCreateOptIdxColor     // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuSubCmdCreateOptCount  // This MUST be the last constant defined in this block
+)
 
-	roleSelectMenuImageOpt    = "image-url"
-	roleSelectMenuImageOptReq = false
+const (
+	roleSelectMenuSubCmdUpdate = "update"
 
-	roleSelectMenuThumbnailOpt    = "thumbnail-url"
-	roleSelectMenuThumbnailOptReq = false
+	roleSelectMenuUpdateOptAction          = "action"
+	roleSelectMenuUpdateOptReqAction       = true
+	roleSelectMenuUpdateOptActionChoiceAdd = "add"
+	roleSelectMenuUpdateOptActionChoiceDel = "delete"
+	roleSelectMenuUpdateOptMsgID           = "message-id"
+	roleSelectMenuUpdateOptReqMsgID        = true
+	roleSelectMenuUpdateOptRole            = "role"
+	roleSelectMenuUpdateOptReqRole         = true
+	roleSelectMenuUpdateOptCtx             = "role-context"
+	roleSelectMenuUpdateOptReqCtx          = false
+)
+const (
+	roleSelectMenuUpdateOptIdxAction = iota
+	roleSelectMenuUpdateOptIdxMsgID
+	roleSelectMenuUpdateOptIdxRole
+	roleSelectMenuUpdateOptIdxCtx      // index only valid when registering the command, since this is an optional argument.
+	roleSelectMenuSubCmdUpdateOptCount // This MUST be the last constant defined in this block
+)
 
-	roleSelectMenuColorOpt    = "embed-color"
-	roleSelectMenuColorOptReq = false
-
+const (
 	roleSelectMenuComponentIDPrefix = "role-select-menu"
 	roleSelectResetButtonID         = "role-select-reset"
 	roleSelectResetButtonLabel      = "Reset your role selection"
 )
 
-var roleSelectMenuIDRegex = func() *regexp.Regexp { return nil }
-
-func init() {
-	r := regexp.MustCompile(fmt.Sprintf(`%s\d*`, roleSelectMenuComponentIDPrefix))
-	if r == nil {
-		log.Fatal("failed to compile roleSelectMenuComponentIDPrefix regex")
-	}
-	roleSelectMenuIDRegex = func() *regexp.Regexp { return r }
-}
-
-func strMatchesRoleSelectMenuID(str string) bool {
-	return roleSelectMenuIDRegex().MatchString(str)
-}
-
-const (
-	roleSelectMenuTitleOptIdx = iota
-	roleSelectRolesOptIdx
-	roleSelectMenuDescOptIdx      // index only valid when registering the command, since this is an optional argument.
-	roleSelectMenuURLOptIdx       // index only valid when registering the command, since this is an optional argument.
-	roleSelectMenuFooterOptIdx    // index only valid when registering the command, since this is an optional argument.
-	roleSelectMenuThumbnailOptIdx // index only valid when registering the command, since this is an optional argument.
-	roleSelectMenuColorOptIdx     // index only valid when registering the command, since this is an optional argument.
-
-	// This MUST be the last constant defined in this block
-	roleSelectOptCount
-)
-
-func roleSelectCmdOpts() []*discordgo.ApplicationCommandOption {
-	opts := make([]*discordgo.ApplicationCommandOption, roleSelectOptCount)
+func roleSelectMenuSubCmdCreateOpts() []*discordgo.ApplicationCommandOption {
+	opts := make([]*discordgo.ApplicationCommandOption, roleSelectMenuSubCmdCreateOptCount)
 	for i := range opts {
 		switch i {
-		// TODO: Add a help option
-		case roleSelectMenuTitleOptIdx:
+		case roleSelectMenuCreateOptIdxTitle:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectMenuTitleOpt,
+				Name:        roleSelectMenuCreateOptTitle,
 				Description: "Title describing this selection of roles",
-				Required:    roleSelectMenuTitleOptReq,
+				Required:    roleSelectMenuCreateOptReqTitle,
 			}
-		case roleSelectRolesOptIdx:
+		case roleSelectMenuCreateOptIdxRoles:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectRolesOpt,
+				Name:        roleSelectMenuCreateOptRoles,
 				Description: fmt.Sprintf("Roles (up to %d) and their context. Ex: @SomeRole context 😺 @NextRole next role context", maxDiscordSelectMenuOpts*maxRoleSelectMenus),
-				Required:    roleSelectRolesOptReq,
+				Required:    roleSelectMenuCreateOptReqRoles,
 			}
-		case roleSelectMenuDescOptIdx:
+		case roleSelectMenuCreateOptIdxDesc:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectMenuDescOpt,
+				Name:        roleSelectMenuCreateOptDesc,
 				Description: "Description of this selection of roles",
-				Required:    roleSelectMenuDescOptReq,
+				Required:    roleSelectMenuCreateOptReqDesc,
 			}
-		case roleSelectMenuURLOptIdx:
+		case roleSelectMenuCreateOptIdxURL:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectMenuURLOpt,
+				Name:        roleSelectMenuCreateOptURL,
 				Description: "URL associated with this selection of roles",
-				Required:    roleSelectMenuURLOptReq,
+				Required:    roleSelectMenuCreateOptReqURL,
 			}
-		case roleSelectMenuFooterOptIdx:
+		case roleSelectMenuCreateOptIdxImage:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectMenuImageOpt,
+				Name:        roleSelectMenuCreateOptImage,
 				Description: "Image URL for this selection of roles",
-				Required:    roleSelectMenuImageOptReq,
+				Required:    roleSelectMenuCreateOptReqImage,
 			}
-		case roleSelectMenuThumbnailOptIdx:
+		case roleSelectMenuCreateOptIdxThumbnail:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
-				Name:        roleSelectMenuThumbnailOpt,
+				Name:        roleSelectMenuCreateOptThumbnail,
 				Description: "Thumbnail URL for this selection of roles",
-				Required:    roleSelectMenuThumbnailOptReq,
+				Required:    roleSelectMenuCreateOptReqThumbnail,
 			}
-		case roleSelectMenuColorOptIdx:
+		case roleSelectMenuCreateOptIdxColor:
 			opts[i] = &discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionInteger,
-				Name:        roleSelectMenuColorOpt,
+				Name:        roleSelectMenuCreateOptColor,
 				Description: "Color to use when creating the message embed",
-				Required:    roleSelectMenuColorOptReq,
+				Required:    roleSelectMenuCreateOptReqColor,
 				Choices: []*discordgo.ApplicationCommandOptionChoice{
 					{
 						Name:  "Red",
@@ -162,10 +167,104 @@ func roleSelectCmdOpts() []*discordgo.ApplicationCommandOption {
 					},
 				},
 			}
+		default:
+			log.Fatalf("Unknown index (%d). There is a bug. :(", i)
 		}
 	}
-
 	return opts
+}
+
+func roleSelectMenuSubCmdUpdateOpts() []*discordgo.ApplicationCommandOption {
+	opts := make([]*discordgo.ApplicationCommandOption, roleSelectMenuSubCmdUpdateOptCount)
+	for i := range opts {
+		switch i {
+		case roleSelectMenuUpdateOptIdxAction:
+			opts[i] = &discordgo.ApplicationCommandOption{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        roleSelectMenuUpdateOptAction,
+				Description: "Are we adding or removing a role from the menu?",
+				Required:    roleSelectMenuUpdateOptReqAction,
+				Choices: []*discordgo.ApplicationCommandOptionChoice{
+					{
+						Name:  roleSelectMenuUpdateOptActionChoiceAdd,
+						Value: roleSelectMenuUpdateOptActionChoiceAdd,
+					},
+					{
+						Name:  roleSelectMenuUpdateOptActionChoiceDel,
+						Value: roleSelectMenuUpdateOptActionChoiceDel,
+					},
+				},
+			}
+		case roleSelectMenuUpdateOptIdxMsgID:
+			opts[i] = &discordgo.ApplicationCommandOption{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        roleSelectMenuUpdateOptMsgID,
+				Description: "ID of the message to update (Enable dev mode -> Right Click Msg -> Copy ID)",
+				Required:    roleSelectMenuUpdateOptReqMsgID,
+			}
+		case roleSelectMenuUpdateOptIdxRole:
+			opts[i] = &discordgo.ApplicationCommandOption{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        roleSelectMenuUpdateOptRole,
+				Description: "Role to add or remove",
+				Required:    roleSelectMenuUpdateOptReqRole,
+			}
+		case roleSelectMenuUpdateOptIdxCtx:
+			opts[i] = &discordgo.ApplicationCommandOption{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        roleSelectMenuUpdateOptCtx,
+				Description: "Context and emojis for this role. This option is ignored if removing the role.",
+				Required:    roleSelectMenuUpdateOptReqCtx,
+			}
+		default:
+			log.Fatalf("Unknown index (%d). There is a bug. :(", i)
+		}
+	}
+	return opts
+}
+
+func roleSelectCmdOpts() []*discordgo.ApplicationCommandOption {
+	return []*discordgo.ApplicationCommandOption{
+		{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        roleSelectMenuSubCmdCreate,
+			Description: "Create a new role selection menu",
+			Options:     roleSelectMenuSubCmdCreateOpts(),
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        roleSelectMenuSubCmdUpdate,
+			Description: "Edit an existing role selection menu",
+			Options:     roleSelectMenuSubCmdUpdateOpts(),
+		},
+	}
+}
+
+var roleSelectMenuIDRegex = func() *regexp.Regexp { return nil }
+
+func init() {
+	r := regexp.MustCompile(fmt.Sprintf(`%s\d*`, roleSelectMenuComponentIDPrefix))
+	if r == nil {
+		log.Fatal("failed to compile roleSelectMenuComponentIDPrefix regex")
+	}
+	roleSelectMenuIDRegex = func() *regexp.Regexp { return r }
+}
+
+func strMatchesRoleSelectMenuID(str string) bool {
+	return roleSelectMenuIDRegex().MatchString(str)
+}
+
+func handleRoleSelectMenuCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.ApplicationCommandData().Options[0].Name {
+	case roleSelectMenuSubCmdCreate:
+		handleRoleSelectMenuCreate(s, i)
+	case roleSelectMenuSubCmdUpdate:
+		interactionRespondEphemeralError(s, i, false, fmt.Errorf("this command not yet implemented"))
+	default:
+		err := fmt.Errorf(`unknown command: "%s"`, i.ApplicationCommandData().Options[0].Name)
+		log.Error(err)
+		interactionRespondEphemeralError(s, i, true, err)
+	}
 }
 
 // Given a discordgo Session and guildID, returns a map of roleID's to Roles for that guild
@@ -202,12 +301,12 @@ func init() {
 
 const roleMentionDelimiter = "<@&"
 
-func parseRoles(i *discordgo.InteractionCreate) ([]string, error) {
-	if !strings.HasPrefix(i.ApplicationCommandData().Options[roleSelectRolesOptIdx].StringValue(), roleMentionDelimiter) {
-		return nil, fmt.Errorf("the first argument to `%s` must be a role mention", roleSelectRolesOpt)
+func parseRoles(rolesOpt string) ([]string, error) {
+	if !strings.HasPrefix(rolesOpt, roleMentionDelimiter) {
+		return nil, fmt.Errorf("the first argument to `%s` must be a role mention", roleSelectMenuCreateOptRoles)
 	}
 
-	rolesAndCtx := strings.Split(i.ApplicationCommandData().Options[roleSelectRolesOptIdx].StringValue(), roleMentionDelimiter)[1:]
+	rolesAndCtx := strings.Split(rolesOpt, roleMentionDelimiter)[1:]
 	if len(rolesAndCtx) > maxDiscordSelectMenuOpts*maxRoleSelectMenus {
 		return nil, fmt.Errorf("you may only specify up to %d roles", maxDiscordSelectMenuOpts*maxRoleSelectMenus)
 	}
@@ -232,9 +331,9 @@ func parseRoles(i *discordgo.InteractionCreate) ([]string, error) {
 	return filteredRolesAndCtx, nil
 }
 
-func buildRoleSelectMenus(s *discordgo.Session, i *discordgo.InteractionCreate, rolesAndCtx []string) ([]discordgo.SelectMenu, error) {
-	if s == nil || i == nil {
-		return nil, fmt.Errorf("nil session (%v) or interaction (%v)", s, i)
+func buildRoleSelectMenus(s *discordgo.Session, metadata interactionMetaData, rolesAndCtx []string) ([]discordgo.SelectMenu, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil session (%v)", s)
 	}
 
 	sMenus := make([]discordgo.SelectMenu, int(math.Ceil(float64(len(rolesAndCtx))/float64(maxDiscordSelectMenuOpts))))
@@ -243,11 +342,6 @@ func buildRoleSelectMenus(s *discordgo.Session, i *discordgo.InteractionCreate, 
 			CustomID:    roleSelectMenuComponentIDPrefix + fmt.Sprint(i),
 			Placeholder: "Select any roles you would like to be added to. 🎭",
 		}
-	}
-
-	metadata, err := getInteractionMetaData(i)
-	if err != nil {
-		return nil, err
 	}
 
 	roleMap, err := guildRoleMap(s, metadata.GuildID)
@@ -311,26 +405,26 @@ func detectAndScrubDiscordEmojis(str string) (discordgo.ComponentEmoji, string, 
 	return emoji, discordgo.EmojiRegex.ReplaceAllString(str, ""), nil
 }
 
-func buildRoleSelectMenuEmbed(i *discordgo.InteractionCreate) *dg_helpers.Embed {
+func buildRoleSelectMenuEmbed(opts []*discordgo.ApplicationCommandInteractionDataOption) *dg_helpers.Embed {
 	embed := dg_helpers.NewEmbed()
-	if i == nil {
-		log.Error("nil interaction")
+	if opts == nil {
+		log.Error("nil opts")
 		return embed
 	}
 
-	for _, opt := range i.ApplicationCommandData().Options {
+	for _, opt := range opts {
 		switch opt.Name {
-		case roleSelectMenuTitleOpt:
+		case roleSelectMenuCreateOptTitle:
 			embed.SetTitle(opt.StringValue())
-		case roleSelectMenuDescOpt:
+		case roleSelectMenuCreateOptDesc:
 			embed.SetDescription(opt.StringValue())
-		case roleSelectMenuImageOpt:
+		case roleSelectMenuCreateOptImage:
 			embed.SetImage(opt.StringValue())
-		case roleSelectMenuURLOpt:
+		case roleSelectMenuCreateOptURL:
 			embed.SetURL(opt.StringValue())
-		case roleSelectMenuThumbnailOpt:
+		case roleSelectMenuCreateOptThumbnail:
 			embed.SetThumbnail(opt.StringValue())
-		case roleSelectMenuColorOpt:
+		case roleSelectMenuCreateOptColor:
 			embed.SetColor(int(opt.IntValue()))
 		}
 	}
@@ -349,7 +443,7 @@ func validateRoleSelectEmbedURLs(e *dg_helpers.Embed) error {
 	return nil
 }
 
-func createRoleSelect(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func handleRoleSelectMenuCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if s == nil || i == nil {
 		log.Errorf("nil Session pointer (%v) and/or InteractionCreate pointer (%v)", s, i)
 		return
@@ -375,19 +469,25 @@ func createRoleSelect(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	rolesAndCtx, err := parseRoles(i)
+	rolesAndCtx, err := parseRoles(i.ApplicationCommandData().Options[0].Options[roleSelectMenuCreateOptIdxRoles].StringValue())
 	if err != nil {
 		interactionFollowUpEphemeralError(s, i, false, err)
 		return
 	}
 
-	sMenus, err := buildRoleSelectMenus(s, i, rolesAndCtx)
+	metadata, err := getInteractionMetaData(i)
+	if err != nil {
+		interactionFollowUpEphemeralError(s, i, true, err)
+		log.Error(err)
+		return
+	}
+	sMenus, err := buildRoleSelectMenus(s, *metadata, rolesAndCtx)
 	if err != nil {
 		interactionFollowUpEphemeralError(s, i, true, err)
 		return
 	}
 
-	e := buildRoleSelectMenuEmbed(i)
+	e := buildRoleSelectMenuEmbed(i.ApplicationCommandData().Options[0].Options)
 	err = validateRoleSelectEmbedURLs(e)
 	if err != nil {
 		interactionFollowUpEphemeralError(s, i, false, err)

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -576,7 +576,17 @@ func handleRoleSelectMenuUpdateAdd(s *discordgo.Session, i *discordgo.Interactio
 			return
 		}
 		if !newOptAdded {
-			interactionFollowUpEphemeralError(s, i, false, fmt.Errorf("the menu is at max capacity. You'll have to remove an option first or create a new menu"))
+			_, err = s.InteractionResponseEdit(s.State.User.ID, i.Interaction, &discordgo.WebhookEdit{
+				Content: fmt.Sprintf(
+					"Congratulations, you've bumped into a Discord API limitation! 🎉 Either you are at the max number of menus (%d), or your existing menus are full and we can't add a new one because discord requires at least %d options per menu. Sorry for the inconvenience! 😔",
+					maxDiscordActionRows,
+					minDiscordSelectMenuOpts,
+				),
+			})
+			if err != nil {
+				interactionFollowUpEphemeralError(s, i, true, err)
+				log.Error(err)
+			}
 			return
 		}
 		content = fmt.Sprintf("Added %s option to the menu", roleToAdd.Mention())

--- a/kardbot/role_select.go
+++ b/kardbot/role_select.go
@@ -696,6 +696,7 @@ func handleRoleSelectMenuUpdateDel(s *discordgo.Session, i *discordgo.Interactio
 				if selectMenu.Options[optIdx].Value == roleToDel.ID {
 					selectMenu.Options[optIdx] = selectMenu.Options[len(selectMenu.Options)-1]
 					selectMenu.Options = selectMenu.Options[:len(selectMenu.Options)-1]
+					selectMenu.MaxValues = len(selectMenu.Options)
 					removed = true
 					break
 				}
@@ -797,6 +798,7 @@ func addRoleSelectMenuOption(s *discordgo.Session, roleToAdd *discordgo.Role, ro
 					Description: roleRegex().ReplaceAllString(sanitizedCtx, ""),
 					Emoji:       emoji,
 				})
+				selectMenu.MaxValues = len(selectMenu.Options)
 				return msgToEdit.Components, true, nil
 			}
 		}

--- a/pprof-scripts/README.md
+++ b/pprof-scripts/README.md
@@ -1,0 +1,12 @@
+# pprof Scripts
+
+Per the [pprof repo](https://github.com/google/pprof) and [module docs](https://pkg.go.dev/net/http/pprof):
+
+> pprof is a tool for visualization and analysis of profiling data.
+
+Kard-bot will optionally start a pprof server if configured to do so in `config/setup.json`.
+The intention behind the scripts in this directory (and this README) is to give me a nudge in
+the right direction when I inevitably can't remember how to use pprof. :)
+
+These scripts are intended to be run from the directory they live in. They depend on a lot of relative paths,
+so they probably won't work if you run them from elsewhere. ¯\\_(ツ)_/¯

--- a/pprof-scripts/contended-mutexes.sh
+++ b/pprof-scripts/contended-mutexes.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/incl.sh"
+
+initialize
+
+MUTEX_PATH="mutex"
+go tool pprof "$(getServer)${MUTEX_PATH}"
+echo "done"

--- a/pprof-scripts/cpu-profile.sh
+++ b/pprof-scripts/cpu-profile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/incl.sh"
+
+initialize
+
+PERIOD="30"
+CPU_PATH="profile?seconds=${PERIOD}"
+go tool pprof "$(getServer)${CPU_PATH}"
+echo "done"

--- a/pprof-scripts/goroutine-blocking-profile.sh
+++ b/pprof-scripts/goroutine-blocking-profile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/incl.sh"
+
+initialize
+
+BLOCK_PATH="block"
+go tool pprof "$(getServer)${BLOCK_PATH}"
+echo "done"

--- a/pprof-scripts/heap-profile.sh
+++ b/pprof-scripts/heap-profile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/incl.sh"
+
+initialize
+
+HEAP_PATH="heap"
+go tool pprof "$(getServer)${HEAP_PATH}"
+echo "done"

--- a/pprof-scripts/incl.sh
+++ b/pprof-scripts/incl.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script doesn't do anything on its own.
+# It's for sharing code between the other scripts in this directory.
+
+CFG="../config/setup.json"
+PPROF_PATH="debug/pprof/"
+
+function getServer {
+  echo "http://$(pprofAddr)/${PPROF_PATH}"
+}
+
+function verifyDeps {
+  if ! command -v jq &>/dev/null; then
+    echo "You need to install jq: https://stedolan.github.io/jq/"
+  fi
+  if ! command -v curl &>/dev/null; then
+    echo "You need to install curl: https://curl.se/"
+  fi
+  if ! command -v go &>/dev/null; then
+    echo "You need to install go: https://go.dev/"
+  fi
+}
+
+function pprofAddr {
+  jq -r .pprof.address "${CFG}"
+}
+
+function verifyServerUp {
+  curl -s -o /dev/null -w '%{http_code}' "$(getServer)"
+}
+
+function initialize {
+  if [[ "$(verifyDeps)" != "" ]]; then
+    verifyDeps
+    exit 1
+  fi
+
+  echo "Checking for pprof server at $(getServer)"
+  serverStatus=$(verifyServerUp)
+  echo "pprof server status ${serverStatus}"
+  if [[ "${serverStatus}" != "200" ]]; then
+    echo "pprof server does not appear to be running"
+    exit 1
+  fi
+}

--- a/pprof-scripts/trace.sh
+++ b/pprof-scripts/trace.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/incl.sh"
+
+initialize
+
+PERIOD=30
+TRACE_PATH="trace?seconds=${PERIOD}"
+TRACE_FILE="trace.$(date +"%Y.%m.%d.%H.%M.%S").out"
+wget -O "${TRACE_FILE}" "$(getServer)${TRACE_PATH}"
+go tool trace "${TRACE_FILE}"


### PR DESCRIPTION
Renames `/create-role-menu` to `/role-select-menu` and offers the subcommands `create` and `update` which allow an admin to update the menus after creation.

I also did some more thorough testing of the role select menus and found that interacting with large menus is painfully slow. To that end, I've added some configurable code profiling options to assist in identifying the slow parts of the code. They are agnostic to this particular issue, so I'm going to leave them in for next time! [`pprof`](https://pkg.go.dev/net/http/pprof) is pretty slick. :)

With any luck, I'll be able to get the menu interactions running a bit quicker as part of this PR. As time allows, I may also try to instrument some even more robust profiling capabilities by adding user defined trace regions to interaction handlers.