### PR TITLE
Additional Image Generation Models

### DIFF
--- a/config/hugging-face-models.json
+++ b/config/hugging-face-models.json
@@ -1,22 +1,63 @@
 {
-  "models": [
-    "runwayml/stable-diffusion-v1-5",
-    "prompthero/openjourney-v4",
-    "nitrosocke/mo-di-diffusion",
-    "wavymulder/Analog-Diffusion",
-    "nitrosocke/redshift-diffusion",
-    "nitrosocke/Ghibli-Diffusion",
-    "Envvi/Inkpunk-Diffusion",
-    "nitrosocke/mo-di-diffusion",
-    "ogkalu/Comic-Diffusion",
-    "nousr/robo-diffusion-2-base",
-    "Fictiverse/Stable_Diffusion_PaperCut_Model",
-    "nitrosocke/elden-ring-diffusion",
-    "dallinmackay/Van-Gogh-diffusion",
-    "Conflictx/Complex-Lineart",
-    "darkstorm2150/Protogen_x3.4_Official_Release",
-    "Aybeeceedee/knollingcase",
-    "wavymulder/portraitplus",
-    "0xJustin/Dungeons-and-Diffusion"
-  ]
+  "models": {
+    "runwayml/stable-diffusion-v1-5": [
+      ""
+    ],
+    "prompthero/openjourney": [
+      "mdjrny-v4 style, "
+    ],
+    "nitrosocke/mo-di-diffusion": [
+      "modern disney style, "
+    ],
+    "wavymulder/Analog-Diffusion": [
+      "analog style, "
+    ],
+    "nitrosocke/redshift-diffusion": [
+      "redshift style, "
+    ],
+    "nitrosocke/Ghibli-Diffusion": [
+      "ghibli style, "
+    ],
+    "Envvi/Inkpunk-Diffusion": [
+      "nvinkpunk, "
+    ],
+    "ogkalu/Comic-Diffusion": [
+      "charliebo artstyle, ",
+      "holliemengert artstyle, ",
+      "marioalberti artstyle, ",
+      "pepelarraz artstyle, ",
+      "andreasrocha artstyle, ",
+      "jamesdaly artstyle, "
+    ],
+    "nousr/robo-diffusion-2-base": [
+      "nousr robot, "
+    ],
+    "Fictiverse/Stable_Diffusion_PaperCut_Model": [
+      "PaperCut, "
+    ],
+    "nitrosocke/elden-ring-diffusion": [
+      "elden ring style, "
+    ],
+    "dallinmackay/Van-Gogh-diffusion": [
+      "lvngvncnt, "
+    ],
+    "Conflictx/Complex-Lineart": [
+      "ComplexLA style, "
+    ],
+    "darkstorm2150/Protogen_x3.4_Official_Release": [
+      "modelshoot style, ",
+      "analog style, ",
+      "mdjrny-v4 style, ",
+      "nousr robot, "
+    ],
+    "Aybeeceedee/knollingcase": [
+      "knollingcase, "
+    ],
+    "wavymulder/portraitplus": [
+      "portrait+ style, "
+    ],
+    "0xJustin/Dungeons-and-Diffusion": [
+      ""
+    ]
+  }
 }

--- a/config/hugging-face-models.json
+++ b/config/hugging-face-models.json
@@ -1,0 +1,22 @@
+{
+  "models": [
+    "runwayml/stable-diffusion-v1-5",
+    "prompthero/openjourney-v4",
+    "nitrosocke/mo-di-diffusion",
+    "wavymulder/Analog-Diffusion",
+    "nitrosocke/redshift-diffusion",
+    "nitrosocke/Ghibli-Diffusion",
+    "Envvi/Inkpunk-Diffusion",
+    "nitrosocke/mo-di-diffusion",
+    "ogkalu/Comic-Diffusion",
+    "nousr/robo-diffusion-2-base",
+    "Fictiverse/Stable_Diffusion_PaperCut_Model",
+    "nitrosocke/elden-ring-diffusion",
+    "dallinmackay/Van-Gogh-diffusion",
+    "Conflictx/Complex-Lineart",
+    "darkstorm2150/Protogen_x3.4_Official_Release",
+    "Aybeeceedee/knollingcase",
+    "wavymulder/portraitplus",
+    "0xJustin/Dungeons-and-Diffusion"
+  ]
+}

--- a/kardbot/commands.go
+++ b/kardbot/commands.go
@@ -356,9 +356,22 @@ func getCommands() []*discordgo.ApplicationCommand {
 			Options:     timeCmdOpts(),
 		},
 		{
-			Name:        dalle2Cmd,
-			Description: "Ask an AI to generate an image from a prompt. Uses Open AI's DALL·E 2.",
-			Options:     dalle2Opts(),
+			Name:        renderCmd,
+			Description: "Ask an AI to generate an image from a prompt.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        dalle2SubCmd,
+					Description: "Ask Open AI's DALL·E 2 model to generate an image from a prompt.",
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Options:     dalle2Opts(),
+				},
+				{
+					Name:        hfSubCmd,
+					Description: "Ask a HuggingFace model to generate an image from a prompt.",
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Options:     hfOpts(),
+				},
+			},
 		},
 		{
 			Name:        helpCmd,
@@ -392,7 +405,7 @@ func getCommandImpls() map[string]onInteractionHandler {
 		madlibCmd:             handleMadLibCmd,
 		timeCmd:               handleTimeCmd,
 		pollCmd:               handlePollCmd,
-		dalle2Cmd:             handleDalle2Cmd,
+		renderCmd:             handleRenderCmd,
 	}
 }
 


### PR DESCRIPTION
This PR replaces `/dalle2` with `/render`, and adds support for additional AI image generation models besides Dalle 2.